### PR TITLE
Add RSS feed fetcher module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+seen_articles.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # langtest
+
 test
+
+## RSS Fetcher
+
+`rss_fetcher.py` fetches new articles from RSS feeds using the `feedparser`
+package. Feed URLs are read from `rss_config.json` or the `RSS_FEEDS`
+environment variable. Run the module directly to print newly discovered
+article titles and links.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+feedparser>=6.0

--- a/rss_config.json
+++ b/rss_config.json
@@ -1,0 +1,3 @@
+[
+  "https://planetpython.org/rss20.xml"
+]

--- a/rss_fetcher.py
+++ b/rss_fetcher.py
@@ -1,0 +1,83 @@
+"""Simple RSS fetcher using feedparser.
+
+Reads feed URLs from ``rss_config.json`` or the ``RSS_FEEDS`` environment
+variable and returns newly discovered articles.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import feedparser
+
+CONFIG_ENV_VAR = "RSS_CONFIG"
+FEEDS_ENV_VAR = "RSS_FEEDS"
+SEEN_FILE = Path("seen_articles.json")
+
+
+def get_feed_urls(config_path: str | None = None) -> List[str]:
+    """Return feed URLs from a config file or environment variable.
+
+    Priority is given to the ``RSS_FEEDS`` environment variable where multiple
+    URLs can be comma separated. Otherwise, a JSON configuration file is
+    loaded. The file path can be supplied via ``config_path`` or the
+    ``RSS_CONFIG`` environment variable. If none of these are provided, the
+    default ``rss_config.json`` is used.
+    """
+    env_feeds = os.getenv(FEEDS_ENV_VAR)
+    if env_feeds:
+        return [u.strip() for u in env_feeds.split(",") if u.strip()]
+
+    path = config_path or os.getenv(CONFIG_ENV_VAR) or "rss_config.json"
+    config_file = Path(path)
+    if config_file.exists():
+        with config_file.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, list):
+            return data
+        return data.get("feeds", [])
+    return []
+
+
+def load_seen() -> set[str]:
+    if SEEN_FILE.exists():
+        with SEEN_FILE.open("r", encoding="utf-8") as handle:
+            return set(json.load(handle))
+    return set()
+
+
+def save_seen(seen: set[str]) -> None:
+    with SEEN_FILE.open("w", encoding="utf-8") as handle:
+        json.dump(sorted(seen), handle, indent=2)
+
+
+def fetch_new_articles(config_path: str | None = None) -> List[Dict[str, str]]:
+    """Fetch new articles from configured RSS feeds.
+
+    Returns a list of dictionaries each containing ``title`` and ``link`` keys.
+    Only articles whose links have not been seen before are returned.
+    """
+    urls = get_feed_urls(config_path)
+    seen = load_seen()
+    new_articles: List[Dict[str, str]] = []
+
+    for url in urls:
+        feed = feedparser.parse(url)
+        for entry in getattr(feed, "entries", []):
+            link = entry.get("link")
+            title = entry.get("title", "")
+            if link and link not in seen:
+                new_articles.append({"title": title, "link": link})
+                seen.add(link)
+
+    if new_articles:
+        save_seen(seen)
+    return new_articles
+
+
+if __name__ == "__main__":
+    articles = fetch_new_articles()
+    for article in articles:
+        print(f"{article['title']} - {article['link']}")


### PR DESCRIPTION
## Summary
- add `rss_fetcher.py` that reads RSS feed URLs from config or env and returns new article titles & links
- include sample `rss_config.json`, `.gitignore`, and `requirements.txt`
- document usage in README

## Testing
- `pip install feedparser`
- `python -m py_compile rss_fetcher.py`
- `python rss_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d83773088327ab241655a89bdcc3