### PR TITLE
Add LangChain loader for RSS feed fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@ test
 package. Feed URLs are read from `rss_config.json` or the `RSS_FEEDS`
 environment variable. Run the module directly to print newly discovered
 article titles and links.
+
+## LangChain Loader
+
+`rss_langchain_loader.py` exposes `RSSFetcherLoader` which wraps the RSS
+fetcher and returns feed entries as LangChain `Document` objects.
+
+```python
+from rss_langchain_loader import RSSFetcherLoader
+
+loader = RSSFetcherLoader("rss_config.json")
+for doc in loader.load():
+    print(doc.metadata["source"], doc.page_content)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 feedparser>=6.0
+langchain-core>=0.2
+langchain-community>=0.2

--- a/rss_langchain_loader.py
+++ b/rss_langchain_loader.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""LangChain loader wrapping the ``rss_fetcher`` utility.
+
+This loader converts newly discovered RSS articles into LangChain
+``Document`` objects so they can be consumed by downstream chains.
+"""
+from langchain_community.document_loaders.base import BaseLoader
+from langchain_core.documents import Document
+
+from rss_fetcher import fetch_new_articles
+
+
+class RSSFetcherLoader(BaseLoader):
+    """Load documents from configured RSS feeds.
+
+    Parameters
+    ----------
+    config_path:
+        Optional path to a JSON configuration file listing feed URLs.
+        Falls back to environment variables as described in
+        :func:`rss_fetcher.get_feed_urls`.
+    """
+
+    def __init__(self, config_path: str | None = None):
+        self.config_path = config_path
+
+    def load(self) -> list[Document]:
+        """Return newly fetched articles as ``Document`` instances."""
+        articles = fetch_new_articles(self.config_path)
+        return [
+            Document(page_content=article["title"], metadata={"source": article["link"]})
+            for article in articles
+        ]


### PR DESCRIPTION
## Summary
- add `RSSFetcherLoader` to turn fetched RSS items into LangChain documents
- document loader usage and add LangChain dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897daccd4b48327a4fadfa47072ee72