### PR TITLE
Add unit tests for RSS utilities

### DIFF
--- a/tests/test_rss_fetcher.py
+++ b/tests/test_rss_fetcher.py
@@ -1,0 +1,44 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import rss_fetcher
+
+
+def test_get_feed_urls_from_config(tmp_path):
+    config = tmp_path / "config.json"
+    feeds = ["http://example.com/feed"]
+    config.write_text(json.dumps(feeds))
+    result = rss_fetcher.get_feed_urls(str(config))
+    assert result == feeds
+
+
+def test_get_feed_urls_env_overrides_config(tmp_path, monkeypatch):
+    config = tmp_path / "config.json"
+    feeds = ["http://example.com/feed"]
+    config.write_text(json.dumps(feeds))
+    env_feeds = "http://env1.com, http://env2.com"
+    monkeypatch.setenv(rss_fetcher.FEEDS_ENV_VAR, env_feeds)
+    result = rss_fetcher.get_feed_urls(str(config))
+    assert result == ["http://env1.com", "http://env2.com"]
+
+
+def test_fetch_new_articles(tmp_path, monkeypatch):
+    config = tmp_path / "config.json"
+    feeds = ["http://example.com/feed"]
+    config.write_text(json.dumps(feeds))
+
+    dummy_feed = SimpleNamespace(entries=[{"link": "http://article1", "title": "Article 1"}])
+    monkeypatch.setattr(rss_fetcher, "feedparser", SimpleNamespace(parse=lambda url: dummy_feed))
+    monkeypatch.setattr(rss_fetcher, "SEEN_FILE", tmp_path / "seen.json")
+
+    articles = rss_fetcher.fetch_new_articles(str(config))
+    assert articles == [{"title": "Article 1", "link": "http://article1"}]
+
+    # second run should yield no new articles because link is now seen
+    articles_again = rss_fetcher.fetch_new_articles(str(config))
+    assert articles_again == []

--- a/tests/test_rss_loader.py
+++ b/tests/test_rss_loader.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from langchain_core.documents import Document
+
+from rss_langchain_loader import RSSFetcherLoader
+
+
+def test_loader_returns_documents(monkeypatch):
+    articles = [{"title": "Article 1", "link": "http://article1"}]
+    monkeypatch.setattr("rss_langchain_loader.fetch_new_articles", lambda config: articles)
+
+    loader = RSSFetcherLoader()
+    docs = loader.load()
+    assert docs == [Document(page_content="Article 1", metadata={"source": "http://article1"})]


### PR DESCRIPTION
## Summary
- Add tests validating config and environment feed retrieval
- Cover deduplication behavior in RSS fetching
- Ensure loader returns LangChain Documents with correct metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897dde8d7308327adf1367ea2f53c75